### PR TITLE
Fix uv in crontab

### DIFF
--- a/crontab_sample
+++ b/crontab_sample
@@ -1,1 +1,1 @@
-*/30 * * * *  flock -n /tmp/szuru-toolkit.lock -c "cd /szurubooru-toolkit && uv run szuru-toolkit auto-tagger -- \"-source:*donmai* -source:*gelbooru* -source:*yande* sort:date,asc\" >/proc/1/fd/1 2>&1"
+*/30 * * * *  flock -n /tmp/szuru-toolkit.lock -c "cd /szurubooru-toolkit && /usr/local/bin/uv run szuru-toolkit auto-tagger -- \"-source:*donmai* -source:*gelbooru* -source:*yande* sort:date,asc\" >/proc/1/fd/1 2>&1"


### PR DESCRIPTION
For some reason, uv is not getting added to the path in the docker container, so when my crontab tries to run, it just says `/bin/sh: 1: uv: not found`. This can be fixed by just adding the explicit uv path to the crontab command. Not sure why this started happening recently