### PR TITLE
Prevent import failure due to "None" artist returned (Twitter)

### DIFF
--- a/src/szurubooru_toolkit/scripts/import_from_url.py
+++ b/src/szurubooru_toolkit/scripts/import_from_url.py
@@ -220,7 +220,9 @@ def main(urls: list = [], input_file: str = '', add_tags: list = [], verbose: bo
                 metadata['tags'] = []
 
             if site == 'twitter':
-                metadata['tags'] += extract_twitter_artist(metadata)
+                    artistname = extract_twitter_artist(metadata)
+                    if not None in artistname:
+                        metadata['tags'] += artistname
 
             if add_tags:
                 metadata['tags'] += add_tags


### PR DESCRIPTION
Update import_from_url.py to include a check if "extract_twitter_artist" returns a None value, as this currently causes an import failure.

This occurs when danbooru search doesn't return a value, and "Use Twitter Artists" config value is off. 

(Also this is my first time creating a PR, and I'm not very familiar with best practices in Python, so sorry if I step on toes here.)