### PR TITLE
adds auto-tag support for rule34

### DIFF
--- a/src/szurubooru_toolkit/scripts/import_from_url.py
+++ b/src/szurubooru_toolkit/scripts/import_from_url.py
@@ -42,7 +42,7 @@ def set_tags(metadata: dict) -> list:
     """
 
     artist = ''
-    allow_tags_for_sites = ['sankaku', 'danbooru', 'gelbooru', 'konachan', 'yandere', 'fanbox', 'pixiv', 'twitter']
+    allow_tags_for_sites = ['sankaku', 'danbooru', 'gelbooru', 'konachan', 'yandere', 'fanbox', 'pixiv', 'twitter', 'rule34']
 
     if metadata['site'] in allow_tags_for_sites:
         try:

--- a/src/szurubooru_toolkit/utils.py
+++ b/src/szurubooru_toolkit/utils.py
@@ -628,6 +628,7 @@ def get_site(url: str) -> str:
         'kemono',
         'fanbox',
         'pixiv',
+        'rule34'
     }
 
     for site in sites:


### PR DESCRIPTION
Includes rule34.xxx in the list of sites to allow_tags_for_sites, allowing auto-populating tags from downloaded json