### PR TITLE
Publish per-extra Docker image variants

### DIFF
--- a/.github/workflows/deploy-to-docker-hub.yml
+++ b/.github/workflows/deploy-to-docker-hub.yml
@@ -6,6 +6,21 @@ on:
 jobs:
   buildx:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          # Default slim image: no optional extras.
+          - suffix: ''
+            extras: ''
+          # Local ML tagging (ONNX Runtime + ffmpeg).
+          - suffix: '-wd-tagger'
+            extras: '--extra wd-tagger'
+          # Pixiv metadata support.
+          - suffix: '-pixiv'
+            extras: '--extra pixiv'
+          # Everything.
+          - suffix: '-all'
+            extras: '--all-extras'
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -27,8 +42,10 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          build-args: |
+            EXTRAS=${{ matrix.extras }}
           push: true
           tags: |
-            ${{ secrets.DOCKER_HUB_USERNAME }}/szurubooru-toolkit:latest
-            ${{ secrets.DOCKER_HUB_USERNAME }}/szurubooru-toolkit:${{ github.ref_name }}
+            ${{ secrets.DOCKER_HUB_USERNAME }}/szurubooru-toolkit:latest${{ matrix.suffix }}
+            ${{ secrets.DOCKER_HUB_USERNAME }}/szurubooru-toolkit:${{ github.ref_name }}${{ matrix.suffix }}
           platforms: linux/amd64

--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,6 @@ dmypy.json
 
 # macOS
 *.DS_Store
+
+# Local-only compose override (e.g. build: . while the published image lacks wd-tagger)
+docker-compose.override.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,17 +3,28 @@ ARG WORKDIR="/szurubooru-toolkit"
 FROM python:3.11-slim
 
 ARG WORKDIR
+# Optional dependency extras to install, passed straight to `uv sync`.
+# Examples:
+#   EXTRAS=""                    -> slim, no extras (default)
+#   EXTRAS="--extra wd-tagger"   -> local WD tagger (ONNX Runtime + ffmpeg)
+#   EXTRAS="--extra pixiv"       -> Pixiv metadata support
+#   EXTRAS="--all-extras"        -> everything
+ARG EXTRAS=""
 
 # Don't buffer `stdout`:
 ENV PYTHONUNBUFFERED=1
 # Don't create `.pyc` files:
 ENV PYTHONDONTWRITEBYTECODE=1
 
+# ffmpeg is only needed for WD tagger video frame sampling, so install it only
+# when the wd-tagger extra is being built.
 RUN apt-get update && apt-get install -y \
   libssl-dev \
   libffi-dev \
   python3-dev \
-  cron
+  cron \
+  && case " $EXTRAS " in *"wd-tagger"*|*"--all-extras"*) apt-get install -y ffmpeg ;; esac \
+  && rm -rf /var/lib/apt/lists/*
 RUN pip3 install --upgrade pip && \
   pip3 install "uv>=0.11.6"
 
@@ -21,7 +32,7 @@ WORKDIR ${WORKDIR}
 COPY . .
 
 COPY uv.lock pyproject.toml README.md ./
-RUN uv sync --frozen --no-dev
+RUN uv sync --frozen --no-dev $EXTRAS
 
 RUN chmod +x /szurubooru-toolkit/entrypoint.sh
 CMD ["/szurubooru-toolkit/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -63,6 +63,22 @@ Alternatively, you can clone the package from GitHub and set everything up with 
 ### Docker Instructions
 If you would like to run the toolkit in a Docker container instead, follow the
 instructions below.
+
+Several image variants are published on each release, matching the optional
+extras. The default image is slim; the others bundle heavier dependencies, so
+pick the smallest one that covers what you enable in `config.toml`:
+
+| Tag | Extras included |
+| --- | --- |
+| `reluce/szurubooru-toolkit:latest` | none (slim, default) |
+| `reluce/szurubooru-toolkit:latest-wd-tagger` | WD tagger (ONNX Runtime + ffmpeg) |
+| `reluce/szurubooru-toolkit:latest-pixiv` | Pixiv metadata support |
+| `reluce/szurubooru-toolkit:latest-all` | everything |
+
+Use the matching tag in your `docker-compose.yml` — e.g. `-wd-tagger` if you set
+`wd_tagger = true`. Every tag is also published per version, e.g. `:2.0.0`,
+`:2.0.0-wd-tagger`, `:2.0.0-pixiv` and `:2.0.0-all`.
+
 <details>
 1. Copy `docker-compose.yml` to the location where you want to run the toolkit.
 


### PR DESCRIPTION
The 2.0.0 Dockerfile built with `uv sync --frozen --no-dev`, which does not install optional dependency groups, so the published image lacked the `wd-tagger` extra and `wdtagger.load_model` failed at runtime with a CRITICAL error telling the user to install `szurubooru-toolkit[wd-tagger]`.

Rather than bloat the default image, gate the optional extras (`wd-tagger`, `pixiv`) behind a build arg and publish an image per variant:

- Dockerfile: add an `EXTRAS` build arg passed straight to `uv sync` (default empty = slim, unchanged). ffmpeg, needed only for WD tagger video sampling, is installed only when the wd-tagger extra is present.
- CI: build a matrix on each tag push, publishing the default image (`:latest`, `:<version>`) plus `-wd-tagger`, `-pixiv` and `-all` variants for both the `latest` and versioned tags.
- README: document the image variants.

Local deployments can build a variant via a gitignored docker-compose.override.yml (EXTRAS + a Hugging Face model cache volume) until the published variant image is available.